### PR TITLE
Støtt sendt til NAV som timestamp

### DIFF
--- a/data/syfosoknader/arbeidstakere.json
+++ b/data/syfosoknader/arbeidstakere.json
@@ -3,6 +3,7 @@
   "fnr": "16086801683",
   "navn": "Karina Mostad",
   "innsendtDato": "2019-09-09",
+  "innsendtTid": "2019-03-16T12:05:55.123456",
   "sendtArbeidsgiver": "2019-09-09",
   "sykmeldingUtskrevet": "2019-09-01",
   "arbeidsgiver": "LØNNS- OG REGNSKAPSSENTERET",

--- a/templates/syfosoknader/partials/base.hbs
+++ b/templates/syfosoknader/partials/base.hbs
@@ -33,6 +33,11 @@
                             Sendt til NAV<br/>{{ iso_to_date innsendtDato }}
                         </p>
                     {{/if}}
+                    {{# if innsendtTid}}
+                        <p>
+                            Sendt til NAV<br/>{{ iso_to_nor_datetime innsendtTid }}
+                        </p>
+                    {{/if}}
                     {{# if sendtArbeidsgiver}}
                         <p>
                             Sendt til arbeidsgiver<br/>{{ iso_to_date sendtArbeidsgiver }}


### PR DESCRIPTION
Rendrer "sent til NAV" som dato og tid hvis feltet innsendtTid er satt.

Det er ikke lagt på logikk som velger mellom dato og tid, så hvis begge felt er satt
rendres begge felt